### PR TITLE
fix(cf_worker): Don’t use `return await` in async functions

### DIFF
--- a/lib/cloudflare_worker.js
+++ b/lib/cloudflare_worker.js
@@ -1,7 +1,13 @@
-addEventListener('fetch', event => {
+/// <reference lib="webworker"/>
+
+addEventListener('fetch', /** @param {FetchEvent} event */ event => {
   event.respondWith(handleRequest(event.request))
 })
 
+/**
+ * @param {Request} request
+ * @return {Promise<Response>}
+ */
 async function handleRequest(request) {
   const match = request.url.match(/\/d\/([^?]+)(\?.+)?/);
   let fetchable;
@@ -22,7 +28,7 @@ async function handleRequest(request) {
     if (!doc.includes('/')) {
       let newUrl = request.url.replace(doc, doc + '/');
       return Response.redirect(newUrl, 301);
-     }
+    }
 
     if (doc.endsWith('/'))
       doc += 'index.html';
@@ -31,6 +37,5 @@ async function handleRequest(request) {
     fetchable = request;
   }
 
-  const response = await fetch(fetchable);
-  return response;
+  return fetch(fetchable);
 }


### PR DESCRIPTION
This adds a slight performance optimisation to the Cloudlfare Worker script.

### External links:
- https://eslint.org/docs/rules/no-return-await
- https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/async_function

---

Also adds [JSDoc](http://usejsdoc.org) to the `handleRequest(…)` function to add intellisense in IDEs.